### PR TITLE
feat: add context manager execution for timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Time Executioner
 
-A simple common decorator library for timing and logging function calls in python, including support for both sync and async function types. 
+A simple common decorator and context manager library for timing and logging function calls in python,
+including support for both sync and async function types.
 
 ## Usage
 
@@ -11,17 +12,23 @@ To use the `TimeExecutioner` package you can simply use the python decorator fea
 ```python
 from time_executioner import TimeExecutioner
 
+
 @TimeExecutioner.log
 def my_cool_method_to_time():
     x = 2
     # ...
 
-def my_cool_method_to_time()
 
 # no difference for async methods:
 @TimeExecutioner.log
 async def my_cool_async_method_to_time():
     x = 2
+    # ...
+
+
+# or you can use it as a context manager
+with TimeExecutioner.time("my-expensive-codeblock"):
+    y = 4
     # ...
 ```
 
@@ -30,22 +37,31 @@ Which will result in automatic logging to the default logger:
 ```
 my_cool_method_to_time() executed in 0.697 seconds
 my_cool_async_method_to_time() executed in 0.173 seconds
+time_execute.my-expensive-codeblock executed in 2.401 seconds
 ```
 
-You can also provide specific logging levels in the decorator (`INFO` is the default) as a parameter. 
+You can also provide specific logging levels in the decorator (`INFO` is the default) as a parameter.
 
 ```python
 from time_executioner import TimeExecutioner
+
 
 @TimeExecutioner.log(log_level="debug")
 def my_cool_method_to_time():
     x = 2
     # ...
+
+
+# or as a context manager: 
+with TimeExecutioner.time("my-expensive-codeblock", log_level="critical"):
+    sleep(1)
 ```
 
-Or, if you'd like to provide a custom logger, assuming that implements the logging.Logger, that is also supported:
+And, finally, if you'd like to provide a custom logger, assuming that implements the logging.Logger, that is also
+supported:
 
 ```python
 logger = EliteCustomLogger()
 TimeExecutioner.set_logger(logger)
 ```
+

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,7 +5,7 @@ Time Executioner - A decorator for measuring execution time of functions
 
 def __version__():
     """Return the version of the simple_stats package."""
-    return "0.0.1"
+    return "0.0.2"
 
 
 def describe():

--- a/src/time_executioner.py
+++ b/src/time_executioner.py
@@ -2,8 +2,9 @@ import asyncio
 import functools
 import logging
 import time
+from contextlib import contextmanager
 from logging import Logger
-from typing import Any, Callable, TypeVar, cast
+from typing import Any, Callable, Generator, Optional, TypeVar, cast
 
 T = TypeVar("T", bound=Callable[..., Any])
 
@@ -18,7 +19,7 @@ class TimeExecutioner:
     class aims to provide a systematic and reusable approach to monitoring performance
     metrics and debugging function executions.
 
-    Defaults to using the built-in logging module, however it can be customized to use
+    Defaults to using the built-in logging module, however, it can be customized to use
     anything that implements the logging.Logger interface.
     """
 
@@ -35,6 +36,48 @@ class TimeExecutioner:
         return self._logger
 
     @staticmethod
+    def _log_execution(
+        log_level: str,
+        start_time: float,
+        func_name: str,
+        class_name: str,
+        is_async: Optional[bool] = False,
+        extra: Optional[dict[str, Any]] = None,
+        error: Optional[Exception | None] = None,
+    ) -> None:
+        """
+        Helper function to handle logging logic
+        """
+
+        execution_time = time.perf_counter() - start_time
+        te = TimeExecutioner()
+
+        # when calling logger.log, you're expected to pass in an int level.
+        # however, the inbuilt logging.getLevelName() is a mess. this
+        # names mapping method is only available in newer versions of python.
+        int_level = logging.getLevelNamesMapping()[log_level.upper()]
+
+        payload = {
+            "function_name": func_name,
+            "class_name": class_name,
+            "execution_time": execution_time,
+            **({"is_async": is_async} if is_async is not None else {}),
+            **({"error": str(error)} if error is not None else {}),
+        }
+
+        if extra is not None:
+            payload = payload | extra
+
+        if error is None:
+            te.logger.log(
+                int_level,
+                f"{class_name}.{func_name}: executed in {execution_time:.3f} seconds",
+                extra=payload,
+            )
+        else:
+            te.logger.error(f"Error in {class_name}.{func_name}: {str(error)}", extra=payload)
+
+    @staticmethod
     def log(f_py: Any = None, log_level: str = "info"):
         """
         the outer decorator function for time executioner logging. Because of how decorators
@@ -47,7 +90,7 @@ class TimeExecutioner:
                   When calling @TimeExecutioner.log(log_level="debug"), f_py is None,
                   but calls _run with the function context.
 
-            log_level (str): log level to use for logging. Defaults to "info".):
+            log_level (str): log level to use for logging. Defaults to "info".
 
         Returns: None
         """
@@ -64,72 +107,75 @@ class TimeExecutioner:
                 Wrapped function that logs its execution time
             """
 
-            def _log_execution(
-                start_time: float,
-                func_name: str,
-                class_name: str,
-                error: Exception | None = None,
-            ) -> None:
-                """
-                Helper function to handle logging logic
-                """
-                execution_time = time.time() - start_time
-                te = TimeExecutioner()
-
-                # when calling logger.log, you're expected to pass in an int level.
-                # however the inbuilt logging.getLevelName() is a mess. this
-                # names mapping method is only available in newer versions of python.
-                int_level = logging.getLevelNamesMapping()[log_level.upper()]
-
-                if error is None:
-                    te.logger.log(
-                        int_level,
-                        f"{class_name}.{func_name}() executed in {execution_time:.3f} seconds",
-                        extra={
-                            "function_name": func_name,
-                            "class_name": class_name,
-                            "execution_time": execution_time,
-                            "is_async": asyncio.iscoroutinefunction(func),
-                        },
-                    )
-                else:
-                    te.logger.error(
-                        f"Error in {class_name}.{func_name}: {str(error)}",
-                        extra={
-                            "function_name": func_name,
-                            "class_name": class_name,
-                            "execution_time": execution_time,
-                            "is_async": asyncio.iscoroutinefunction(func),
-                            "error": str(error),
-                        },
-                    )
-
             @functools.wraps(func)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
-                start_time = time.time()
+                start_time = time.perf_counter()
+                func_name = f"{func.__name__}()"
                 class_name = args[0].__class__.__name__ if args else ""
-
+                is_async = asyncio.iscoroutinefunction(func)
                 try:
                     result = await func(*args, **kwargs)
-                    _log_execution(start_time, func.__name__, class_name)
+                    TimeExecutioner._log_execution(
+                        log_level, start_time, func_name, class_name, is_async
+                    )
+
                     return result
                 except Exception as e:
-                    _log_execution(start_time, func.__name__, class_name, error=e)
+                    TimeExecutioner._log_execution(
+                        log_level,
+                        start_time,
+                        func_name,
+                        class_name,
+                        is_async,
+                        error=e,
+                    )
                     raise
 
             @functools.wraps(func)
             def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
-                start_time = time.time()
+                start_time = time.perf_counter()
+                func_name = f"{func.__name__}()"
                 class_name = args[0].__class__.__name__ if args else ""
+                is_async = asyncio.iscoroutinefunction(func)
 
                 try:
                     result = func(*args, **kwargs)
-                    _log_execution(start_time, func.__name__, class_name)
+                    TimeExecutioner._log_execution(
+                        log_level, start_time, func_name, class_name, is_async
+                    )
                     return result
                 except Exception as e:
-                    _log_execution(start_time, func.__name__, class_name, error=e)
+                    TimeExecutioner._log_execution(
+                        log_level,
+                        start_time,
+                        func_name,
+                        class_name,
+                        is_async,
+                        error=e,
+                    )
                     raise
 
             return cast(T, async_wrapper if asyncio.iscoroutinefunction(func) else sync_wrapper)
 
         return _run(f_py) if callable(f_py) else _run
+
+    @staticmethod
+    @contextmanager
+    def time(
+        label: str, log_level: str = "info", extra: dict[str, Any] | None = None
+    ) -> Generator[Any, None, None]:
+        """
+        a context manager for time executioner logging. Allows you to time and log a block of code.
+
+        Args:
+            label (str): a label to identify the block of code
+            log_level (str): an optional log level to use for logging. Defaults to "info".
+            extra (dict): an optional dictionary of extra data to include in the log message
+        """
+
+        start_time = time.perf_counter()
+        try:
+            yield
+        finally:
+            msg = f"{label}"
+            TimeExecutioner._log_execution(log_level, start_time, msg, "time_execute", extra=extra)


### PR DESCRIPTION
Per @HillelW's request, adding in a context manager application.

You can now:

```python
    with TimeExecutioner.time("my-expensive-code-block"):
        sleep(10)
        # ...
```
I've also done some minor cleanup and refactoring, and moved the timer time time.time() to time.perf_counter()